### PR TITLE
Add id property to description

### DIFF
--- a/src/opts.cr
+++ b/src/opts.cr
@@ -66,7 +66,7 @@ module Opts
           parser.on({{short}}, {{long}}, "{{desc.id}} (default: {{default.id}}).") {|x| self.{{name.var}} = x}
         {% end %}
       {% else %}
-         parser.on({{short}}, {{long}}, "{{desc}}.") {self.{{name.var}} = true}
+         parser.on({{short}}, {{long}}, "{{desc.id}}.") {self.{{name.var}} = true}
       {% end %}
     end
   end


### PR DESCRIPTION
The short/long flag macro was missing the id property in its description. 